### PR TITLE
Avoid removing real files when case-insensitive

### DIFF
--- a/config/Makefile.am.lib
+++ b/config/Makefile.am.lib
@@ -42,16 +42,20 @@ add-local-names:
 add-names:
 	@ cd $(DESTDIR)$(moduledir);					\
 	for file in $(EXTRA_NAMES); do					\
-	   realfile=`echo $$file | tr '[A-Z]' '[a-z]'`;			\
-	   echo " linking $$file to $$realfile";			\
-	   rm -f $$file;						\
-	   $(LN_S) $$realfile $$file;					\
+	    if test ! -e $$file -o -L $$file; then			\
+	        realfile=`echo $$file | tr '[A-Z]' '[a-z]'`;		\
+	        echo " linking $$file to $$realfile";			\
+	        rm -f $$file;						\
+	        $(LN_S) $$realfile $$file;				\
+	    fi								\
 	done
 
 remove-names:
 	@ for file in $(EXTRA_NAMES); do				\
-	   echo " unlinking $$file";					\
-	   rm -f $(DESTDIR)$(moduledir)/$$file;				\
+	    if test -L $$file; then					\
+	        echo " unlinking $$file";				\
+	        rm -f $(DESTDIR)$(moduledir)/$$file;			\
+	    fi								\
 	done
 
 CLEANFILES = $(MODULES) $(EXTRA_NAMES)

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -43,14 +43,19 @@ remove-localdir:
 add-names:
 	@ cd $(DESTDIR)$(includedir);					\
 	for file in $(EXTRA_NAMES); do					\
-	   realfile=`echo $$file | tr '[A-Z]' '[a-z]'`;			\
-	   echo " linking $$file to $$realfile";			\
-	   rm -f $$file;						\
-	   $(LN_S) $$realfile $$file;					\
+	    if test ! -e $$file -o -L $$file; then			\
+	        realfile=`echo $$file | tr '[A-Z]' '[a-z]'`;		\
+	        echo " linking $$file to $$realfile";			\
+	        rm -f $$file;						\
+	        $(LN_S) $$realfile $$file;				\
+	    fi								\
 	done
 
 remove-names:
 	@ for file in $(EXTRA_NAMES); do				\
-	   echo " unlinking $$file";					\
-	   rm -f $(DESTDIR)$(includedir)/$$file;			\
+	    if test -L $$file; then					\
+	        echo " unlinking $$file";				\
+	        rm -f $(DESTDIR)$(includedir)/$$file;			\
+	    fi								\
 	done
+


### PR DESCRIPTION
Case-insensitive filesystems (such as OS X uses by default) have various
important things such as parser.h removed during the add-names step;
check for this situation and avoid doing the removal/link if Parser.h is
already a real file.
