### PR TITLE
Don't strip the Inform binary by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ MAN_PREFIX = $(PREFIX)
 VERSION = 6.33.1
 NAME = inform
 BINNAME = $(NAME)
+BINDIR = $(PREFIX)/bin
 DISTNAME = $(BINNAME)-$(VERSION)
 distdir = $(DISTNAME)
 LIBDIR = $(PREFIX)/share/$(BINNAME)/lib
@@ -59,7 +60,8 @@ tutor:	lib $(BINNAME) $(TUTOR_Z5)
 
 install: $(BINNAME) lib
 	strip $(BINNAME)
-	install -c -m 755 $(BINNAME) $(PREFIX)/bin
+	install -d -m 755 $(BINDIR)
+	install -c -m 755 $(BINNAME) $(BINDIR)
 	install -d -m 755 $(LIBDIR)
 	install -c -m 644 $(wildcard lib/*) $(LIBDIR)
 	install -d -m 755 $(INCLUDEDIR)

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,10 @@ demos:	lib $(BINNAME) $(DEMO_Z5)
 
 tutor:	lib $(BINNAME) $(TUTOR_Z5)
 
-install: $(BINNAME) lib
+strip: $(BINNAME)
 	strip $(BINNAME)
+
+install: $(BINNAME) lib
 	install -d -m 755 $(BINDIR)
 	install -c -m 755 $(BINNAME) $(BINDIR)
 	install -d -m 755 $(LIBDIR)
@@ -72,6 +74,8 @@ install: $(BINNAME) lib
 	install -c -m 644 $(wildcard demos/*) $(DEMODIR)
 	install -d -m 755 $(TUTORDIR)
 	install -c -m 644 $(wildcard demos/*) $(TUTORDIR)
+
+install-strip: strip install
 
 
 uninstall:


### PR DESCRIPTION
Stripping the binary only saves ~300 KB of space, but the debugging symbols are occasionally useful, and desirable in rpm packages.

By default the debugging symbols are not built unless one does the following:

    $ make OPT="-g"

Therefore this commit does not change the default behavior. It is however a useful change for building packages with debugging symbols.

This commit is based upon another commit which has its own pull request. If you do not want the other pull request, I can rebase this commit for you.