### PR TITLE
Some changes to help packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GIT = git
 
 #OPTS = -g -Wall -Wextra
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 MAN_PREFIX = $(PREFIX)
 
 COMPVERSION = 6.33

--- a/Makefile
+++ b/Makefile
@@ -81,20 +81,20 @@ else
 endif
 
 install: $(BINNAME) lib
-	install -d -m 755 $(BINDIR)
-	install -c -m 755 $(BINNAME) $(BINDIR)
-	install -d -m 755 $(LIBDIR)
-	install -c -m 644 $(wildcard ${LIBSRC}/*) $(LIBDIR)
-	install -d -m 755 $(INCLUDEDIR)
-	install -c -m 644 $(wildcard include/*) $(INCLUDEDIR)
-	install -d -m 755 $(MANDIR)
-	install -c -m 644 $(MANPAGE) $(MANDIR)
-	install -d -m 755 $(DEMODIR)
-	install -c -m 644 $(wildcard ${DEMO}/*) $(DEMODIR)
-	install -d -m 755 $(TUTORDIR)
-	install -c -m 644 $(wildcard ${TUTOR}/*) $(TUTORDIR)
-	install -c -m 755 contrib/pblorb.pl $(BINDIR)
-	install -c -m 755 contrib/scanblorb.pl $(BINDIR)
+	install -d -m 755 $(DESTDIR)$(BINDIR)
+	install -c -m 755 $(BINNAME) $(DESTDIR)$(BINDIR)
+	install -d -m 755 $(DESTDIR)$(LIBDIR)
+	install -c -m 644 $(wildcard ${LIBSRC}/*) $(DESTDIR)$(LIBDIR)
+	install -d -m 755 $(DESTDIR)$(INCLUDEDIR)
+	install -c -m 644 $(wildcard include/*) $(DESTDIR)$(INCLUDEDIR)
+	install -d -m 755 $(DESTDIR)$(MANDIR)
+	install -c -m 644 $(MANPAGE) $(DESTDIR)$(MANDIR)
+	install -d -m 755 $(DESTDIR)$(DEMODIR)
+	install -c -m 644 $(wildcard ${DEMO}/*) $(DESTDIR)$(DEMODIR)
+	install -d -m 755 $(DESTDIR)$(TUTORDIR)
+	install -c -m 644 $(wildcard ${TUTOR}/*) $(DESTDIR)$(TUTORDIR)
+	install -c -m 755 contrib/pblorb.pl $(DESTDIR)$(BINDIR)
+	install -c -m 755 contrib/scanblorb.pl $(DESTDIR)$(BINDIR)
 
 install-strip: strip install
 


### PR DESCRIPTION
Hi!

I've updated a package of inform in a package manager. I didn't test it out yet, but I've had to make these changes that I understand are common.

I've added $(DESTDIR) to the install paths - our packaging infrastructure expects the installation to happen to a particular directory rather than the real one (that contains more things), as we later make a tarball from this directory. if it's unset, it behaves as before.

Also, we commonly override PREFIX and install to a /home/username/pkg or /usr/pkg, rather than /usr/local. so I've made a change to make it possible to override.

An additional request: could you consider posting a link to the source code used to make the release on the inform website? it was hard to find, and the github releases don't seem to contain the submodules and use a different version number.